### PR TITLE
Add "apk upgrade" to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk21
 FROM folioci/alpine-jre-openjdk21:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE mod-inventory-import-fat.jar
 


### PR DESCRIPTION
This bumps vulnerable packages to fixed versions.

See https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk21